### PR TITLE
Properly handling None passed as MenuItem callback, to disable item

### DIFF
--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -392,7 +392,10 @@ class MenuItem(Menu):
 
     def set_callback(self, callback, key=''):
         self._ns_to_py_and_callback[self._menuitem] = self, callback
-        self._menuitem.setAction_('callback:')
+        if callback is None:
+            self._menuitem.setAction_(None)
+        else:
+            self._menuitem.setAction_('callback:')
         self._menuitem.setTarget_(type(self))
         self._menuitem.setKeyEquivalent_(key)
 


### PR DESCRIPTION
I've been using a combined version of @tito's and @hiroshi's forks, but here's a little contribution from me.

I needed a way to reliably disable a MenuItem instance, i.e. one that had already got a callback set. I wanted to disable it by removing the callback. Passing `None` to `.set_callback()` didn't seem to work all the time, so I added a check to ensure the callback is properly removed.
