### PR TITLE
remove Mac from OS X

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 rumps
 =====
 
-**R**\ idiculously **U**\ ncomplicated **M**\ ac os x **P**\ ython **S**\ tatusbar apps.
+**R**\ idiculously **U**\ ncomplicated **M**\ OS X **P**\ ython **S**\ tatusbar apps.
 
 .. image:: https://raw.github.com/jaredks/rumps/master/examples/rumps_example.png
 
@@ -56,8 +56,8 @@ Required
 * PyObjC
 * Python 2.6+
 
-Mac OS X 10.6 was shipped with Python 2.6 as the default version and PyObjC has been included in the default Python
-since 10.5. If you're using Mac OS X 10.6+ and the default Python that came with it, then ``rumps`` should be
+OS X 10.6 was shipped with Python 2.6 as the default version and PyObjC has been included in the default Python
+since 10.5. If you're using OS X 10.6+ and the default Python that came with it, then ``rumps`` should be
 good to go!
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Welcome to rumps
 
 rumps is...
 
-Ridiculously Uncomplicated Mac os x Python Statusbar apps!
+Ridiculously Uncomplicated OS X Python Statusbar apps!
 
 rumps exposes Objective-C classes as Python classes and functions which greatly simplifies the process of creating a statusbar application.
 

--- a/rumps/__init__.py
+++ b/rumps/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# rumps: Ridiculously Uncomplicated Mac os x Python Statusbar apps.
+# rumps: Ridiculously Uncomplicated OS X Python Statusbar apps.
 # Copyright: (c) 2014, Jared Suttles. All rights reserved.
 # License: BSD, see LICENSE for details.
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -10,7 +10,7 @@
 rumps
 =====
 
-Ridiculously Uncomplicated Mac os x Python Statusbar apps.
+Ridiculously Uncomplicated OS X Python Statusbar apps.
 
 rumps exposes Objective-C classes as Python classes and functions which greatly simplifies the process of creating a
 statusbar application.

--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -1,7 +1,8 @@
+
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# rumps: Ridiculously Uncomplicated Mac os x Python Statusbar apps.
+# rumps: Ridiculously Uncomplicated OS X Python Statusbar apps.
 # Copyright: (c) 2014, Jared Suttles. All rights reserved.
 # License: BSD, see LICENSE for details.
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -71,7 +72,7 @@ def alert(title=None, message='', ok=None, cancel=None):
 
 
 def notification(title, subtitle, message, data=None, sound=True):
-    """Send a notification to Notification Center (Mac OS X 10.8+). If running on a version of Mac OS X that does not
+    """Send a notification to Notification Center (OS X 10.8+). If running on a version of OS X that does not
     support notifications, a ``RuntimeError`` will be raised. Apple says,
 
         "The userInfo content must be of reasonable serialized size (less than 1k) or an exception will be thrown."
@@ -86,7 +87,7 @@ def notification(title, subtitle, message, data=None, sound=True):
     :param sound: whether the notification should make a noise when it arrives.
     """
     if not _NOTIFICATIONS:
-        raise RuntimeError('Mac OS X 10.8+ is required to send notifications')
+        raise RuntimeError('OS X 10.8+ is required to send notifications')
     if data is not None and not isinstance(data, Mapping):
         raise TypeError('notification data must be a mapping')
     _require_string_or_none(title, subtitle, message)

--- a/rumps/utils.py
+++ b/rumps/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# rumps: Ridiculously Uncomplicated Mac os x Python Statusbar apps.
+# rumps: Ridiculously Uncomplicated OS X Python Statusbar apps.
 # Copyright: (c) 2014, Jared Suttles. All rights reserved.
 # License: BSD, see LICENSE for details.
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('CHANGES.rst') as f:
 setup(
     name='rumps',
     version=rumps.__version__,
-    description='Ridiculously Uncomplicated Mac os x Python Statusbar apps.',
+    description='Ridiculously Uncomplicated OS X Python Statusbar apps.',
     author='Jared Suttles',
     url='https://github.com/jaredks/rumps',
     packages=['rumps', 'rumps.packages'],


### PR DESCRIPTION
This fixes a few OSX and Os X typos.

Also removes all the "Mac"s

http://www.theverge.com/2012/2/16/2802281/apple-officially-renames-mac-os-x-to-os-x-drops-the-mac
