### PR TITLE
Workaround for pyobjc/pyinstaller compatibility.

### DIFF
--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -7,6 +7,12 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 _NOTIFICATIONS = True
+
+# For compatibility with pyinstaller
+# See: http://stackoverflow.com/questions/21058889/pyinstaller-not-finding-pyobjc-library-macos-python
+import Foundation
+import AppKit
+
 try:
     from Foundation import NSUserNotification, NSUserNotificationCenter
 except ImportError:


### PR DESCRIPTION
For some reason, to help `pyinstaller` find the `pyobjc` library we need to first import the top level package before we import a module from the package.
