### PR TITLE
Fix for Issue #9 - running without Info.plist

### DIFF
--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -13,7 +13,7 @@ except ImportError:
     _NOTIFICATIONS = False
 
 from Foundation import (NSDate, NSTimer, NSRunLoop, NSDefaultRunLoopMode, NSSearchPathForDirectoriesInDomains,
-                        NSMakeRect, NSLog, NSObject)
+                        NSMakeRect, NSLog, NSObject, NSBundle)
 from AppKit import NSApplication, NSStatusBar, NSMenu, NSMenuItem, NSAlert, NSTextField, NSImage
 from PyObjCTools import AppHelper
 
@@ -921,6 +921,9 @@ class App(object):
         if menu is not None:
             self.menu = menu
         self._application_support = application_support(self._name)
+
+        if not 'CFBundleIdentifier' in NSBundle.mainBundle().infoDictionary():
+           NSBundle.mainBundle().infoDictionary()['CFBundleIdentifier'] = name
 
     # Properties
     #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
NSUserNotificationCenter.defaultNotificationCenter() returns None if there
is no CFBundleIdentifier in python's plist (MacOS app configuration) file.

The default system python has an associated plist; but pythons run in a
virtualenv do not.

This fix force-sets the CFBundleIdentifier field to be the application name
if it is not already set in the plist.