### PR TITLE
Add support for secure text entry in rumps.Window

### DIFF
--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -14,7 +14,7 @@ except ImportError:
 
 from Foundation import (NSDate, NSTimer, NSRunLoop, NSDefaultRunLoopMode, NSSearchPathForDirectoriesInDomains,
                         NSMakeRect, NSLog, NSObject)
-from AppKit import NSApplication, NSStatusBar, NSMenu, NSMenuItem, NSAlert, NSTextField, NSImage
+from AppKit import NSApplication, NSStatusBar, NSMenu, NSMenuItem, NSAlert, NSTextField, NSSecureTextField, NSImage
 from PyObjCTools import AppHelper
 
 import os
@@ -674,7 +674,8 @@ class Window(object):
     :param dimensions: the size of the editable textbox. Must be sequence with a length of 2.
     """
 
-    def __init__(self, message='', title='', default_text='', ok=None, cancel=None, dimensions=(320, 160)):
+    def __init__(self, message='', title='', default_text='', ok=None, cancel=None, dimensions=(320, 160),
+                 secure=False):
         message = unicode(message)
         title = unicode(title)
 
@@ -689,7 +690,10 @@ class Window(object):
             title, ok, cancel, None, message)
         self._alert.setAlertStyle_(0)  # informational style
 
-        self._textfield = NSTextField.alloc().initWithFrame_(NSMakeRect(0, 0, *dimensions))
+        if not secure:
+            self._textfield = NSTextField.alloc().initWithFrame_(NSMakeRect(0, 0, *dimensions))
+        else:
+            self._textfield = NSSecureTextField.alloc().initWithFrame_(NSMakeRect(0, 0, *dimensions))
         self._textfield.setSelectable_(True)
         self._alert.setAccessoryView_(self._textfield)
 


### PR DESCRIPTION
Added an import of NSSecureTextField from AppKit and a bool argument
(‘secure’) to rumps.Window that will use the NSSecureTextField in place
of the standard NSTextField. Passing ‘secure=True’ will provide a text
box that hides the user’s input (use case: password prompt).

rumps.Window using NSSecureTextField:
![screen shot 2015-04-29 at 9 20 59 pm](https://cloud.githubusercontent.com/assets/3086245/7405318/9f6438b0-eeb6-11e4-9fe7-ff1192eca82c.png)

Tested on 10.9 and 10.10.
