### PR TITLE
(Fix) String compatibility for python3:

### DIFF
--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -25,6 +25,14 @@ from .utils import ListDict
 _TIMERS = weakref.WeakKeyDictionary()
 separator = object()
 
+try:
+    unicode = unicode
+    bytes = str
+    basestring = basestring
+except NameError:
+    # unicode didn't exist, we are in python3
+    unicode = str
+    basestring = (str, bytes)
 
 def debug_mode(choice):
     """Enable/disable printing helpful information for debugging the program. Default is off."""


### PR DESCRIPTION
    (Fix)(Issue): https://github.com/jaredks/rumps/issues/57
    Use top file global definition to ensure compatibility with python3 and python2.

    Credits to:
        http://www.rfk.id.au/blog/entry/preparing-pyenchant-for-python-3/