### PR TITLE
Escape percent sign to prevent a ValueError

### DIFF
--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -61,6 +61,7 @@ def alert(title=None, message='', ok=None, cancel=None):
     :return: a number representing the button pressed. The "ok" button is ``1`` and "cancel" is ``0``.
     """
     message = text_type(message)
+    message = message.replace('%', '%%')
     if title is not None:
         title = text_type(title)
     _require_string_or_none(ok)
@@ -742,6 +743,7 @@ class Window(object):
 
     def __init__(self, message='', title='', default_text='', ok=None, cancel=None, dimensions=(320, 160)):
         message = text_type(message)
+        message = message.replace('%', '%%')
         title = text_type(title)
 
         self._cancel = bool(cancel)


### PR DESCRIPTION
Otherwise this would throw an exception:
```python
rumps.alert(message='99 %')

ValueError: Too few arguments for format string [cur:5/len:5]
```
