### PR TITLE
Fix insert_before Python 3.5+

### DIFF
--- a/rumps/packages/ordereddict.py
+++ b/rumps/packages/ordereddict.py
@@ -5,7 +5,10 @@
 try:
     from thread import get_ident as _get_ident
 except ImportError:
-    from dummy_thread import get_ident as _get_ident
+    try:
+        from dummy_thread import get_ident as _get_ident
+    except ImportError:
+        from threading import get_ident as _get_ident
 
 try:
     from _abcoll import KeysView, ValuesView, ItemsView

--- a/rumps/utils.py
+++ b/rumps/utils.py
@@ -5,10 +5,7 @@
 # Copyright: (c) 2017, Jared Suttles. All rights reserved.
 # License: BSD, see LICENSE for details.
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-try:  # Python 2.7+
-    from collections import OrderedDict as _OrderedDict
-except ImportError:
-    from .packages.ordereddict import OrderedDict as _OrderedDict
+from .packages.ordereddict import OrderedDict as _OrderedDict
 
 
 # ListDict: OrderedDict subclass with insertion methods for modifying the order of the linked list in O(1) time


### PR DESCRIPTION
Fixes https://github.com/jaredks/rumps/issues/67

`OrderedDict` became built-in type in more recent versions of python.

While https://github.com/jaredks/rumps/pull/78 fixes the issue for Python 3.5+ it breaks it for earlier versions since the implementation has changed.

I believe this works for all versions since it will just use the pre-packaged class.