### PR TITLE
Add secure text field

### DIFF
--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -14,7 +14,7 @@ except ImportError:
 
 from Foundation import (NSDate, NSTimer, NSRunLoop, NSDefaultRunLoopMode, NSSearchPathForDirectoriesInDomains,
                         NSMakeRect, NSLog, NSObject)
-from AppKit import NSApplication, NSStatusBar, NSMenu, NSMenuItem, NSAlert, NSTextField, NSImage
+from AppKit import NSApplication, NSStatusBar, NSMenu, NSMenuItem, NSAlert, NSTextField, NSSecureTextField, NSImage
 from PyObjCTools import AppHelper
 
 import inspect
@@ -754,9 +754,11 @@ class Window(object):
                    evaluates to ``True``, will create a button with text "Cancel". Otherwise, this button will not be
                    created.
     :param dimensions: the size of the editable textbox. Must be sequence with a length of 2.
+    :param secure: should the text field be secured or not. With True the window can be used for passwords.
     """
 
-    def __init__(self, message='', title='', default_text='', ok=None, cancel=None, dimensions=(320, 160)):
+    def __init__(self, message='', title='', default_text='', ok=None, cancel=None, dimensions=(320, 160),
+                 secure=False):
         message = text_type(message)
         message = message.replace('%', '%%')
         title = text_type(title)
@@ -772,7 +774,8 @@ class Window(object):
             title, ok, cancel, None, message)
         self._alert.setAlertStyle_(0)  # informational style
 
-        self._textfield = NSTextField.alloc().initWithFrame_(NSMakeRect(0, 0, *dimensions))
+        text_field_type = NSSecureTextField if secure else NSTextField
+        self._textfield = text_field_type.alloc().initWithFrame_(NSMakeRect(0, 0, *dimensions))
         self._textfield.setSelectable_(True)
         self._alert.setAccessoryView_(self._textfield)
 


### PR DESCRIPTION
This pull request closes #48 and #37, as well as the issue #76.

The implementation uses a ternary operator to set which text field is being used, instead of the if-else blocks used in the other pull requests. The semantic difference between them was `if not bool` and `if bool`.

Both pull requests have not been touched for a long time, and need to merge in master before being ready for a pull request. So instead, there is now this.

I will merge this pull request in 48 hours if there are no concerns or observations withstanding.