### PR TITLE
Feature: Settings as JSON file

### DIFF
--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -1208,3 +1208,8 @@ class App(object):
         self._nsapp.initializeStatusBar()
 
         AppHelper.runEventLoop()
+
+    def quit(self, sender=None):
+        """Save settings before quitting application. Can be overridden, but should call super if it is."""
+        self.settings = self.settings
+        quit_application(sender)


### PR DESCRIPTION
This pull request will add the ability to read a JSON file from the support folder, as well as write a prettified JSON file to the support folder.

With these functions, an additional `_persistent_settings` variable has been added, which uses a setter to update its contents.

This is not a perfect solution, but it has been helpful in rapid app development starting with a variable on the app that can serialize a dictionary into JSON between runs and threads.