### PR TITLE
Add rumps.App.on_before_event_loop callback. Add .menuitem attribute to every function decorated with @rumps.clicked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 *.py[co]
 
 .idea/
+*.egg-info
+venv/

--- a/examples/example_init.py
+++ b/examples/example_init.py
@@ -1,0 +1,19 @@
+import rumps
+
+
+@rumps.clicked('Switch next')
+def switch_next(_):
+    switch_previous.menuitem.state = not switch_previous.menuitem.state
+
+
+@rumps.clicked('Switch previous')
+def switch_previous(_):
+    switch_next.menuitem.state = not switch_next.menuitem.state
+
+
+def init_app():
+    switch_next.menuitem.state = True
+
+
+if __name__ == "__main__":
+    rumps.App('First item should be checked', on_before_event_loop=init_app).run()

--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -283,41 +283,6 @@ def timer(interval):
     return decorator
 
 
-class _ClickedProxy(object):
-    """
-    Replaces a function or a method decorated with :func:`clicked`
-    and allows both transparent function calls as well as access to :class:`rumps.MenuItem` instance
-    through :meth:`rumps._ClickedProxy.menuitem`.
-
-    See `examples/example_init.py` for usage.
-    """
-    def __init__(self, fn):
-        """
-        Proxy that transparently
-        :param fn:
-        """
-        self._fn = fn
-        self._menuitem = None
-
-    @property
-    def menuitem(self):
-        """
-        :returns: :class:`MenuItem` instance, or `None` in case of proxy has not yet been initialized
-        """
-        return self._menuitem
-
-    @menuitem.setter
-    def menuitem(self, value):
-        """
-        Sets MenuItem instance.
-        :param value: :class:`MenuItem` instance
-        """
-        self._menuitem = value
-
-    def __call__(self, *args, **kwargs):
-        return self._fn(*args, **kwargs)
-
-
 def clicked(*args, **options):
     """Decorator for registering a function as a callback for a click action on a :class:`rumps.MenuItem` within the
     application. The passed `args` must specify an existing path in the main menu. The :class:`rumps.MenuItem`
@@ -337,10 +302,8 @@ def clicked(*args, **options):
     :param args: a series of strings representing the path to a :class:`rumps.MenuItem` in the main menu of the
                  application.
     :param key: a string representing the key shortcut as an alternative means of clicking the menu item.
-    :returns: A :class:`rumps._ClickedProxy` that allows to access menu items
     """
     def decorator(f):
-        callback_proxy = wraps(f)(_ClickedProxy(f))
 
         def register_click(self):
             menuitem = self._menu  # self not defined yet but will be later in 'run' method
@@ -353,13 +316,13 @@ def clicked(*args, **options):
                     menuitem.add(arg)
                     menuitem = menuitem[arg]
             menuitem.set_callback(f, options.get('key'))
-            callback_proxy.menuitem = menuitem
+            setattr(f, 'menuitem', menuitem)
 
         # delay registering the button until we have a current instance to be able to traverse the menu
         buttons = clicked.__dict__.setdefault('*buttons', [])
         buttons.append(register_click)
 
-        return callback_proxy
+        return f
     return decorator
 
 


### PR DESCRIPTION
Hi! I've added a few lines so the application and menu items could now be initialized more conveniently. Here is an example, also committed as `examples/example_init.py`:
```
import rumps

@rumps.clicked('Switch next')
def switch_next(_):
    switch_previous.menuitem.state = not switch_previous.menuitem.state

@rumps.clicked('Switch previous')
def switch_previous(_):
    switch_next.menuitem.state = not switch_next.menuitem.state

def init_app():
    switch_next.menuitem.state = True

if __name__ == "__main__":
    rumps.App('First item should be checked', on_before_event_loop=init_app).run()
```

My intention was to solve my problem around item state initialization. However it looks like it could be used for little bit more purposes as I tried to demonstrate in the example above.