### PR TITLE
Fix ListDict.clear

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: init test test-all
+
+init:
+	pip install -e .[dev]
+
+test: init
+	pytest tests
+
+test-all: init
+	tox

--- a/rumps/packages/ordereddict.py
+++ b/rumps/packages/ordereddict.py
@@ -82,7 +82,7 @@ class OrderedDict(dict):
     def clear(self):
         'od.clear() -> None.  Remove all items from od.'
         try:
-            for node in self.__map.itervalues():
+            for node in self.__map.values():
                 del node[:]
             root = self.__root
             root[:] = [root, root, None]

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,15 @@ setup(
     package_data={'': ['LICENSE']},
     long_description=readme + '\n\n' + changes,
     license='BSD License',
-    install_requires=['pyobjc-framework-Cocoa'],
+    install_requires=[
+        'pyobjc-framework-Cocoa'
+    ],
+    extras_require={
+        'dev': [
+            'pytest>=4.3',
+            'tox>=3.8'
+        ]
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: MacOS X',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from rumps.utils import ListDict
+
+
+class TestListDict(object):
+    def test_clear(self):
+        ld = ListDict()
+
+        ld[1] = 11
+        ld['b'] = 22
+        ld[object()] = 33
+        assert len(ld) == 3
+
+        ld.clear()
+        assert len(ld) == 0
+        assert ld.items() == []

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27,py34,py35,py36,py37
+
+[testenv]
+whitelist_externals = pytest
+commands = pytest tests


### PR DESCRIPTION
**Changes**
* Add test framework code
* Fix `ListDict.clear` and add test

Less obvious error than it could have been since there was a `AttributeError` block that caught a different attribute error than what was intended.

Fixes https://github.com/jaredks/rumps/issues/107