### PR TITLE
Include user reply in notification callback

### DIFF
--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -1065,7 +1065,7 @@ class NSApp(NSObject):
         notification_center.removeDeliveredNotification_(notification)
         ns_dict = notification.userInfo()
         if ns_dict is None:
-            data = None
+            data = {}
         else:
             dumped = ns_dict['value']
             app = getattr(App, '*app_instance')
@@ -1080,6 +1080,7 @@ class NSApp(NSObject):
             try:
                 data['activationType'] = notification.activationType()
                 data['actualDeliveryDate'] = notification.actualDeliveryDate()
+                data['response'] = notification.response()
                 _call_as_function_or_method(notification_function, data)
             except Exception:
                 _log(traceback.format_exc())


### PR DESCRIPTION
When showing a notification with `has_reply_button=True`, the user's reply is now included in the dict passed to the `@rumps.notifications` handler in the `response` key.

Also fixes a crash due to `data` not always being initialised properly in `userNotificationCenter_didActivateNotification_`.