### PR TITLE
Add empty sleep and wake methods

### DIFF
--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -1167,3 +1167,17 @@ class App(object):
 
         AppHelper.installMachInterrupt()
         AppHelper.runEventLoop()
+
+    def sleep(self):
+        """Method being run when system is going to sleep
+
+        To be overridden in your app
+        """
+        pass
+
+    def wake(self):
+        """Method being run when system awakes from sleep
+
+        To be overridden in your app
+        """
+        pass


### PR DESCRIPTION
This prevents exceptions like

```
AttributeError: 'YourApp' object has no attribute 'sleep'
  File "rumps/rumps.py", line 954, in receiveSleepNotification_
```

/cc @mdbraber 