### PR TITLE
Make `SeparatorMenuItem` available at `rumps` module

### DIFF
--- a/rumps/__init__.py
+++ b/rumps/__init__.py
@@ -24,7 +24,7 @@ __copyright__ = 'Copyright 2020 Jared Suttles'
 
 from . import notifications as _notifications
 from .rumps import (separator, debug_mode, alert, application_support, timers, quit_application, timer,
-                    clicked, MenuItem, SliderMenuItem, Timer, Window, App, slider)
+                    clicked, MenuItem, SliderMenuItem, SeparatorMenuItem, Timer, Window, App, slider)
 
 notifications = _notifications.on_notification
 notification = _notifications.notify


### PR DESCRIPTION
Unable to use `SeparatorMenuItem` without importing `rumps.rumps`. So I've added it to the `__init__.py` file and it solved the problem.

Example:

```python
import rumps

rumps.App(
  name='Example',
  menu=[
    rumps.MenuItem(title='Item 1'),
    rumps.SeparatorMenuItem(),
  ]
)
```