### PR TITLE
Feature: Segmented Controls

### DIFF
--- a/docs/SegmentedMenuItem.rst
+++ b/docs/SegmentedMenuItem.rst
@@ -1,0 +1,5 @@
+SegmentedMenuItem
+=================
+
+.. autoclass:: rumps.SegmentedMenuItem
+   :members:

--- a/docs/SeparatorMenuItem.rst
+++ b/docs/SeparatorMenuItem.rst
@@ -1,0 +1,5 @@
+SeparatorMenuItem
+=================
+
+.. autoclass:: rumps.SeparatorMenuItem
+   :members:

--- a/docs/SliderMenuItem.rst
+++ b/docs/SliderMenuItem.rst
@@ -1,0 +1,5 @@
+SliderMenuItem
+==============
+
+.. autoclass:: rumps.SliderMenuItem
+   :members:

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -8,4 +8,7 @@ rumps Classes
    MenuItem
    Window
    Response
+   SegmentedMenuItem
+   SeparatorMenuItem
+   SliderMenuItem
    Timer

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -6,6 +6,8 @@ rumps Functions
 
    notifications
    clicked
+   segmented
+   slider
    timerfunc
    timers
    application_support

--- a/docs/segmented.rst
+++ b/docs/segmented.rst
@@ -1,0 +1,4 @@
+segmented
+=========
+
+.. autofunction:: rumps.segmented

--- a/docs/slider.rst
+++ b/docs/slider.rst
@@ -1,0 +1,4 @@
+slider
+======
+
+.. autofunction:: rumps.slider

--- a/examples/example_segmented_control.py
+++ b/examples/example_segmented_control.py
@@ -1,8 +1,8 @@
 import rumps
 
 @rumps.segmented(segments=["10"])
-def button_press(self, sender):
-    print(self, sender)
+def button_press(sender):
+    print(sender)
 
 app = rumps.App('Segments', quit_button=rumps.MenuItem('Quit', key='q'))
 app.menu = [

--- a/examples/example_segmented_control.py
+++ b/examples/example_segmented_control.py
@@ -1,10 +1,10 @@
 import rumps
 
 @rumps.segmented(segments=["10"])
-def button_press(sender):
-    print("Button pressed!")
+def button_press(self, sender):
+    print(self, sender)
 
-app = rumps.App('Buzz Application', quit_button=rumps.MenuItem('Quit Buzz', key='q'))
+app = rumps.App('Segments', quit_button=rumps.MenuItem('Quit', key='q'))
 app.menu = [
     rumps.SegmentedMenuItem(["1", "2", "3"], multiselect=True, style='bordered', callback=lambda item: print("Current selection:", item.selection)),
     rumps.SegmentedMenuItem(["4", "5", "6"], style='rectangular', callback=lambda item: print("Selected", item.selection[0])),

--- a/examples/example_segmented_control.py
+++ b/examples/example_segmented_control.py
@@ -1,0 +1,13 @@
+import rumps
+
+@rumps.segmented(segments=["10"])
+def button_press(sender):
+    print("Button pressed!")
+
+app = rumps.App('Buzz Application', quit_button=rumps.MenuItem('Quit Buzz', key='q'))
+app.menu = [
+    rumps.SegmentedMenuItem(["1", "2", "3"], multiselect=True, style='bordered', callback=lambda item: print("Current selection:", item.selection)),
+    rumps.SegmentedMenuItem(["4", "5", "6"], style='rectangular', callback=lambda item: print("Selected", item.selection[0])),
+    rumps.SegmentedMenuItem(["7", "8", "9"], momentary=True, style='separated', callback=lambda item: print("Clicked", item.selection[0])),
+]
+app.run()

--- a/rumps/__init__.py
+++ b/rumps/__init__.py
@@ -24,7 +24,7 @@ __copyright__ = 'Copyright 2020 Jared Suttles'
 
 from . import notifications as _notifications
 from .rumps import (separator, debug_mode, alert, application_support, timers, quit_application, timer,
-                    clicked, MenuItem, SliderMenuItem, Timer, Window, App, slider)
+                    clicked, MenuItem, SliderMenuItem, SegmentedMenuItem, Timer, Window, App, slider, segmented)
 
 notifications = _notifications.on_notification
 notification = _notifications.notify

--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -768,16 +768,16 @@ class SegmentedMenuItem(object):
 
         :param callback: the function to be called when the user drags the marker on the slider.
         """
-        def wrapped_callback(s):
+        def wrapped_callback(sender):
             index = self._control.selectedSegment()
             if not self.__multiselect:
                 self.__state = [False for _ in self.__state]
             self.__state[index] = not self.__state[index]
             if callable(callback):
-                callback(s)
+                _internal.call_as_function_or_method(callback, sender)
 
         NSApp._ns_to_py_and_callback[self._control] = self, wrapped_callback
-        self._control.setAction_('callback:')
+        self._control.setAction_('callback:' if callback is not None else None)
 
     @property
     def callback(self):


### PR DESCRIPTION
**Summary:**

Adds supports for segmented control menu items, an example which uses them, and supporting documentation. Also updates the documentation to include docs for slider and separator menu items.

Segmented controls are sets of buttons that can be switched on and off, optionally allowing multiple selections at a time. This PR adds a `SegmentedMenuItem` class alongside a `segmented` decorator which allows users to easily define segmented controls with a list of strings as the button titles. Users can also specify whether to support multiselection, whether the selection should be momentary (i.e. act as a one-off button) or not, the style of the button set, and a callback function.

**Example:**

```python
import rumps

@rumps.segmented(segments=["10"])
def button_press(sender):
    print(sender.selection)

app = rumps.App('Segments', quit_button=rumps.MenuItem('Quit', key='q'))
app.menu = [
    rumps.SegmentedMenuItem(["1", "2", "3"], multiselect=True, style='bordered', callback=lambda item: print("Current selection:", item.selection)),
    rumps.SegmentedMenuItem(["4", "5", "6"], style='rectangular', callback=lambda item: print("Selected", item.selection[0])),
    rumps.SegmentedMenuItem(["7", "8", "9"], momentary=True, style='separated', callback=lambda item: print("Clicked", item.selection[0])),
]
app.run()
```

**Image:**

<img width="297" alt="SegmentedControl" src="https://user-images.githubusercontent.com/7865925/226231091-d1296464-e9b6-4ab8-abf3-a7d2f3352ca3.png">
