### PR TITLE
chore: add `kalimba` to `README.rst`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -306,6 +306,9 @@ Works Made With rumps
 `istat - Lingdu0
 <https://github.com/Lingdu0/istat/>`_
 
+`kalimba (Colima Menu Bar) - dee-me-tree-or-love
+<https://github.com/dee-me-tree-or-love/kalimba>`_
+
 `keynote_snap - sasn0
 <https://github.com/sasn0/keynote_snap/>`_
 


### PR DESCRIPTION
# What

Adding a link to the <https://github.com/dee-me-tree-or-love/kalimba> GH project - a little menu app to monitor and toggle the status of the [Colima](https://github.com/abiosoft/colima) (container runtime for MacOs)

## Example

From `kalimba`'s [README](https://github.com/dee-me-tree-or-love/kalimba?tab=readme-ov-file#start-the-kalimba-menu-bar-app): 

> ![image](https://github.com/jaredks/rumps/assets/12134172/b5a688f0-ba7f-41c1-8b23-55821a224c6f)
