### PR TITLE
docs: minor documentation fix in rumps/docs/examples.rst

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -90,7 +90,7 @@ Menu items can be disabled (greyed out) by passing ``None`` to :meth:`rumps.Menu
     
     @rumps.clicked('Clean Quit')
     def clean_up_before_quit(_):
-        print 'execute clean up code'
+        print('execute clean up code')
         rumps.quit_application()
     
     


### PR DESCRIPTION
There is a minor documentation fix in rumps/docs/examples.rst.

### before
```
        print 'execute clean up code'
```
### After
```
        print('execute clean up code')
```
