### PR TITLE
Add TextFieldMenuItem feature with editable text fields in menu dropdown

### DIFF
--- a/docs/TextFieldMenuItem.md
+++ b/docs/TextFieldMenuItem.md
@@ -1,0 +1,104 @@
+# TextFieldMenuItem Feature
+
+This feature adds support for editable text fields directly within menu bar dropdowns in rumps.
+
+## Overview
+
+`TextFieldMenuItem` is a new menu item type that embeds an `NSTextField` control, allowing users to type text directly into the menu without opening a separate window. It follows the same pattern as the existing `SliderMenuItem`.
+
+## Features
+
+- **Direct text input** in menu dropdowns
+- **Placeholder text** support
+- **Callback function** triggered when text changes or Enter is pressed
+- **Programmatic access** to current text value
+- **Decorator pattern** for easy integration with menu hierarchy
+
+## Usage
+
+### Method 1: Direct Instantiation
+
+```python
+import rumps
+
+class MyApp(rumps.App):
+    def __init__(self):
+        super(MyApp, self).__init__("My App")
+        
+        # Create a text field menu item
+        self.search_field = rumps.TextFieldMenuItem(
+            value='',
+            placeholder='Search...',
+            callback=self.on_search
+        )
+        
+        self.menu = ['Search', self.search_field]
+    
+    def on_search(self, sender):
+        search_text = sender.value
+        print(f"Search: {search_text}")
+```
+
+### Method 2: Using the Decorator
+
+```python
+import rumps
+
+class MyApp(rumps.App):
+    @rumps.text_field('Settings', 'Username', value='admin', placeholder='Enter username')
+    def on_username_changed(self, sender):
+        username = sender.value
+        print(f"Username: {username}")
+```
+
+## API Reference
+
+### TextFieldMenuItem
+
+**Constructor Parameters:**
+- `value` (str): Initial text value (default: '')
+- `placeholder` (str): Placeholder text when field is empty (default: '')
+- `callback` (callable): Function called when text changes (default: None)
+- `dimensions` (tuple): Width and height in pixels (default: (180, 22))
+- `margins` (tuple): Left, top, right, bottom margins in pixels (default: (10, 4, 10, 4))
+
+**Properties:**
+- `value`: Get or set the current text value
+- `placeholder`: Get or set the placeholder text
+- `callback`: Get the current callback function
+
+**Methods:**
+- `set_callback(callback)`: Set or change the callback function
+
+### text_field Decorator
+
+```python
+@rumps.text_field(*path, value='', placeholder='', callback=None, dimensions=(200, 24), margins=(15, 5, 15, 5))
+def my_callback(self, sender):
+    text = sender.value
+    # Handle text change
+```
+
+**Parameters:**
+- `*path`: Menu path where the text field should be placed (e.g., 'Settings', 'User Info', 'Username')
+- `value`: Initial text value
+- `placeholder`: Placeholder text
+- `callback`: Callback function (optional, will use the decorated function)
+- `dimensions`: Width and height in pixels
+- `margins`: Left, top, right, bottom margins in pixels
+
+## Examples
+
+See `examples/example_text_field.py` for a complete working example.
+
+## Implementation Details
+
+- Built using native macOS `NSTextField` control
+- Follows the same pattern as `SliderMenuItem`
+- Uses `NSView` container for proper menu integration
+- Leverages existing rumps callback mechanism via `NSApp._ns_to_py_and_callback`
+
+## Compatibility
+
+- Requires macOS (uses PyObjC and AppKit)
+- rumps version 0.4.1+

--- a/examples/example_text_field.py
+++ b/examples/example_text_field.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Example demonstrating TextFieldMenuItem - editable text fields in menu bar dropdowns.
+
+This example shows:
+1. Creating a TextFieldMenuItem directly with custom styling
+2. Using the @text_field decorator
+3. Accessing and updating text field values
+4. Using callbacks when text changes
+5. Customizing margins and dimensions
+"""
+
+import rumps
+
+
+class TextFieldApp(rumps.App):
+    def __init__(self):
+        super(TextFieldApp, self).__init__("Text Field Demo")
+        
+        # Create a TextFieldMenuItem directly with custom styling
+        self.search_field = rumps.TextFieldMenuItem(
+            value='',
+            placeholder='Search...',
+            callback=self.on_search_changed,
+            dimensions=(200, 24),  # Custom size
+            margins=(15, 5, 15, 5)  # Custom margins for better spacing
+        )
+        
+        # Create a compact text field with tighter margins
+        self.quick_note = rumps.TextFieldMenuItem(
+            value='',
+            placeholder='Quick note...',
+            callback=self.on_note_changed,
+            dimensions=(180, 20),
+            margins=(8, 3, 8, 3)
+        )
+        
+        # Add it to the menu
+        self.menu = [
+            'Status',
+            rumps.separator,
+            'Search',
+            self.search_field,
+            rumps.separator,
+            'Quick Note',
+            self.quick_note,
+            rumps.separator,
+            'Settings',
+        ]
+    
+    def on_search_changed(self, sender):
+        """Called when the search field text changes."""
+        search_text = sender.value
+        print(f"Search text changed: {search_text}")
+        # Update the status item
+        self.menu['Status'].title = f"Last search: {search_text if search_text else '(empty)'}"
+    
+    def on_note_changed(self, sender):
+        """Called when the quick note field changes."""
+        note = sender.value
+        print(f"Quick note: {note}")
+    
+    @rumps.text_field('Settings', 'Username', value='admin', placeholder='Enter username', dimensions=(160, 22))
+    def on_username_changed(self, sender):
+        """Called when the username field changes."""
+        username = sender.value
+        print(f"Username changed: {username}")
+    
+    @rumps.text_field('Settings', 'API Key', placeholder='Enter your API key', dimensions=(200, 22), margins=(12, 4, 12, 4))
+    def on_api_key_changed(self, sender):
+        """Called when the API key field changes."""
+        api_key = sender.value
+        print(f"API key changed: {api_key}")
+
+
+if __name__ == '__main__':
+    TextFieldApp().run()

--- a/rumps/__init__.py
+++ b/rumps/__init__.py
@@ -24,7 +24,7 @@ __copyright__ = 'Copyright 2020 Jared Suttles'
 
 from . import notifications as _notifications
 from .rumps import (separator, debug_mode, alert, application_support, timers, quit_application, timer,
-                    clicked, MenuItem, SliderMenuItem, Timer, Window, App, slider)
+                    clicked, MenuItem, SliderMenuItem, TextFieldMenuItem, Timer, Window, App, slider, text_field)
 
 notifications = _notifications.on_notification
 notification = _notifications.notify


### PR DESCRIPTION
# Add TextFieldMenuItem: Editable text fields in menu bar dropdowns

## Overview
This PR adds a new `TextFieldMenuItem` class that allows editable text fields to appear directly inside menu bar dropdowns, following the same pattern as the existing `SliderMenuItem`.

## Motivation
Menu bar apps often need to collect simple text input from users (searches, API keys, usernames, etc.). Currently, this requires opening separate windows or alerts. With `TextFieldMenuItem`, users can type directly into the menu, providing a more streamlined and native macOS experience.

## Features
- **Native NSTextField integration** - Built around macOS `NSTextField` for native look and feel
- **Modern styling** - Rounded corners with proper bezeling, matching macOS design standards
- **Customizable appearance** - Configurable dimensions and margins for flexible layouts
- **Decorator support** - `@text_field` decorator for declarative menu creation
- **Callback system** - Triggers callback when text changes or Enter is pressed
- **Property access** - Get/set text value and placeholder programmatically

## Usage

### Direct instantiation:
```python
import rumps

class MyApp(rumps.App):
    def __init__(self):
        super(MyApp, self).__init__("My App")
        
        self.search_field = rumps.TextFieldMenuItem(
            placeholder='Search...',
            callback=self.on_search,
            dimensions=(200, 24),
            margins=(15, 5, 15, 5)
        )
        
        self.menu = ['Search', self.search_field]
    
    def on_search(self, sender):
        print(f"Search: {sender.value}")
```

### Using the decorator:
```python
@rumps.text_field('Settings', 'Username', value='admin', placeholder='Enter username')
def on_username_changed(self, sender):
    print(f"Username: {sender.value}")
```

## Implementation Details
- Follows the exact same architecture as `SliderMenuItem` for consistency
- Uses `NSView` container with `NSTextField` child
- Integrates with existing callback mechanism via `NSApp._ns_to_py_and_callback`
- Default dimensions: 200×24 pixels
- Default margins: 15px left/right, 5px top/bottom
- Applies `NSTextFieldRoundedBezel` style for modern appearance

## API

### TextFieldMenuItem
**Parameters:**
- `value` (str): Initial text value (default: '')
- `placeholder` (str): Placeholder text (default: '')
- `callback` (callable): Function called on text change (default: None)
- `dimensions` (tuple): Width and height in pixels (default: (200, 24))
- `margins` (tuple): Left, top, right, bottom margins (default: (15, 5, 15, 5))

**Properties:**
- `value` - Get/set current text
- `placeholder` - Get/set placeholder text
- `callback` - Get current callback function

**Methods:**
- `set_callback(callback)` - Set or change callback function

## Files Changed
- rumps.py - Added `TextFieldMenuItem` class and `text_field` decorator
- __init__.py - Exported new class and decorator
- example_text_field.py - Complete working example with various configurations
- TextFieldMenuItem.md - Full API documentation

## Testing
Tested on macOS with PyObjC. The feature integrates seamlessly with existing rumps apps and follows the same patterns as other menu item types.

## Backwards Compatibility
This is a purely additive change with no breaking modifications to existing functionality.