### PR TITLE
Fix unused imports in __init__.py and tests (F401)

### DIFF
--- a/rumps/__init__.py
+++ b/rumps/__init__.py
@@ -23,8 +23,12 @@ __license__ = 'Modified BSD'
 __copyright__ = 'Copyright 2020 Jared Suttles'
 
 from . import notifications as _notifications
-from .rumps import (separator, debug_mode, alert, application_support, timers, quit_application, timer,
-                    clicked, MenuItem, SliderMenuItem, TextFieldMenuItem, Timer, Window, App, slider, text_field)
+from .rumps import (separator as separator, debug_mode as debug_mode, alert as alert,
+                    application_support as application_support, timers as timers,
+                    quit_application as quit_application, timer as timer,
+                    clicked as clicked, MenuItem as MenuItem, SliderMenuItem as SliderMenuItem,
+                    TextFieldMenuItem as TextFieldMenuItem, Timer as Timer, Window as Window,
+                    App as App, slider as slider, text_field as text_field)
 
 notifications = _notifications.on_notification
 notification = _notifications.notify

--- a/rumps/compat.py
+++ b/rumps/compat.py
@@ -21,7 +21,6 @@ if not PY2:
 
     iteritems = lambda d: iter(d.items())
 
-    import collections.abc as collections_abc
 
 else:
     binary_type = ()
@@ -30,4 +29,3 @@ else:
 
     iteritems = lambda d: d.iteritems()
 
-    import collections as collections_abc

--- a/rumps/rumps.py
+++ b/rumps/rumps.py
@@ -7,12 +7,11 @@
 
 # For compatibility with pyinstaller
 # See: http://stackoverflow.com/questions/21058889/pyinstaller-not-finding-pyobjc-library-macos-python
-import Foundation
 import AppKit
 
 from Foundation import (NSDate, NSTimer, NSRunLoop, NSDefaultRunLoopMode, NSSearchPathForDirectoriesInDomains,
-                        NSMakeRect, NSLog, NSObject, NSMutableDictionary, NSString, NSUserDefaults)
-from AppKit import NSApplication, NSStatusBar, NSMenu, NSMenuItem, NSAlert, NSTextField, NSSecureTextField, NSImage, NSSlider, NSSize, NSWorkspace, NSWorkspaceWillSleepNotification, NSWorkspaceDidWakeNotification, NSView
+                        NSMakeRect, NSLog, NSObject, NSUserDefaults)
+from AppKit import NSApplication, NSStatusBar, NSMenu, NSMenuItem, NSAlert, NSTextField, NSImage, NSSlider, NSSize, NSWorkspace, NSWorkspaceWillSleepNotification, NSWorkspaceDidWakeNotification, NSView
 from PyObjCTools import AppHelper
 
 import os

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 
 from rumps._internal import guard_unexpected_errors
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 
 from rumps.utils import ListDict
 


### PR DESCRIPTION
Fix unused imports flagged by Ruff rule F401 across __init__.py, source, and test files.